### PR TITLE
Fix sample command in 4.a

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ book to summarize is: Name of the Wind
 ```
 Notice that quotation marks are necessary in order for the entire book name to be interpretted as a single parameter.
 ```
-$ sh summarize_reviews.sh "Name of the Wind"
+$ sh summarize_reviews.sh Name of the Wind
 book to summarize is: Name
 ```
 


### PR DESCRIPTION
Removed the extra quotation marks from the following command  to match the output.
```
$ sh summarize_reviews.sh "Name of the Wind"
book to summarize is: Name
```